### PR TITLE
Add `Date::today()` and `DateTime::now()`

### DIFF
--- a/src/date.rs
+++ b/src/date.rs
@@ -154,11 +154,11 @@ impl Date {
         days * 86400 + UNIX_1600
     }
 
-    /// Current date. Uses [DateTime::now]
+    /// Current date. Internally, this uses [DateTime::now].
     ///
     /// # Arguments
     ///
-    /// * `offset` - timezone offset in seconds, meaning as per [DateTime], must be less than `86_400`
+    /// * `offset` - timezone offset in seconds, meaning as per [DateTime::now], must be less than `86_400`
     ///
     /// # Example
     ///

--- a/src/date.rs
+++ b/src/date.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::{get_digit_unchecked, ParseError};
+use crate::{get_digit_unchecked, DateTime, ParseError};
 
 /// A Date
 ///
@@ -152,6 +152,24 @@ impl Date {
             + (self.ordinal_day() - 1) as i64
             + intervening_leap_years(self.year - 1600) as i64;
         days * 86400 + UNIX_1600
+    }
+
+    /// Current date. Uses [DateTime::now]
+    ///
+    /// # Arguments
+    ///
+    /// * `offset` - timezone offset in seconds, meaning as per [DateTime], must be less than `86_400`
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use speedate::Date;
+    ///
+    /// let d = Date::today(0).unwrap();
+    /// println!("The date today is: {}", d)
+    /// ```
+    pub fn today(offset: i32) -> Result<Self, ParseError> {
+        Ok(DateTime::now(offset)?.date)
     }
 
     /// Day of the year, starting from 1.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,8 @@ pub enum ParseError {
     OutOfRangeTz,
     /// timezone is required to adjust to a new timezone
     TzRequired,
+    /// Error getting system time
+    SystemTimeError,
     /// month value is outside expected range of 1-12
     OutOfRangeMonth,
     /// day value is outside expected range

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,8 @@ pub enum ParseError {
     OutOfRangeTzMinute,
     /// timezone offset must be less than 24 hours
     OutOfRangeTz,
+    /// timezone is required to adjust to a new timezone
+    TzRequired,
     /// month value is outside expected range of 1-12
     OutOfRangeMonth,
     /// day value is outside expected range

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -445,13 +445,13 @@ fn datetime_now_offset() {
 
 #[test]
 fn datetime_with_tz_offset() {
-    let dt_z = DateTime::parse_str("2022-01-01T12:13:14+00:00").unwrap();
+    let dt_z = DateTime::parse_str("2022-01-01T12:13:14.567+00:00").unwrap();
 
     let dt_m8 = dt_z.with_timezone_offset(Some(-8 * 3600)).unwrap();
-    assert_eq!(dt_m8.to_string(), "2022-01-01T12:13:14-08:00");
+    assert_eq!(dt_m8.to_string(), "2022-01-01T12:13:14.567-08:00");
 
     let dt_naive = dt_z.with_timezone_offset(None).unwrap();
-    assert_eq!(dt_naive.to_string(), "2022-01-01T12:13:14");
+    assert_eq!(dt_naive.to_string(), "2022-01-01T12:13:14.567");
 
     let dt_naive = DateTime::parse_str("2000-01-01T00:00:00").unwrap();
 
@@ -467,13 +467,13 @@ fn datetime_with_tz_offset() {
 
 #[test]
 fn datetime_in_timezone() {
-    let dt_z = DateTime::parse_str("2000-01-01T15:00:00Z").unwrap();
+    let dt_z = DateTime::parse_str("2000-01-01T15:00:00.567Z").unwrap();
 
     let dt_p1 = dt_z.in_timezone(3_600).unwrap();
-    assert_eq!(dt_p1.to_string(), "2000-01-01T16:00:00+01:00");
+    assert_eq!(dt_p1.to_string(), "2000-01-01T16:00:00.567+01:00");
 
     let dt_m2 = dt_z.in_timezone(-7_200).unwrap();
-    assert_eq!(dt_m2.to_string(), "2000-01-01T13:00:00-02:00");
+    assert_eq!(dt_m2.to_string(), "2000-01-01T13:00:00.567-02:00");
 
     let dt_naive = DateTime::parse_str("2000-01-01T00:00:00").unwrap();
     let error = match dt_naive.in_timezone(3_600) {


### PR DESCRIPTION
fix #19,

Required for https://github.com/pydantic/pydantic-core/issues/229