### PR TITLE
Fix dumping of 0s duration

### DIFF
--- a/src/duration.rs
+++ b/src/duration.rs
@@ -77,6 +77,9 @@ impl fmt::Display for Duration {
             }
             write!(f, "S")?;
         }
+        if self.second == 0 && self.microsecond == 0 && self.day == 0 {
+            write!(f, "T0S")?;
+        }
         Ok(())
     }
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -917,7 +917,6 @@ fn duration_simple() {
     assert_eq!(d.to_string(), "P1Y");
 }
 
-
 #[test]
 fn duration_zero() {
     let d = Duration::parse_str("PT0S").unwrap();
@@ -932,7 +931,6 @@ fn duration_zero() {
     );
     assert_eq!(d.to_string(), "PT0S");
 }
-
 
 #[test]
 fn duration_total_seconds() {

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -917,6 +917,23 @@ fn duration_simple() {
     assert_eq!(d.to_string(), "P1Y");
 }
 
+
+#[test]
+fn duration_zero() {
+    let d = Duration::parse_str("PT0S").unwrap();
+    assert_eq!(
+        d,
+        Duration {
+            positive: true,
+            day: 0,
+            second: 0,
+            microsecond: 0
+        }
+    );
+    assert_eq!(d.to_string(), "PT0S");
+}
+
+
 #[test]
 fn duration_total_seconds() {
     let d = Duration::parse_str("P1MT1.5S").unwrap();


### PR DESCRIPTION
`"P"` is not a valid ISO 8601 duration