### PR TITLE
Fix negative `TzOffset` `to_string` handling

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -58,16 +58,16 @@ impl fmt::Display for Time {
             if tz_offset == 0 {
                 write!(f, "Z")?;
             } else {
-                let mins = tz_offset / 60;
-                let mut min = mins / 60;
-                let sec = (mins % 60).abs();
+                // tz offset is given in seconds, so we do convertions from seconds -> mins -> hours
+                let total_minutes = tz_offset / 60;
+                let hours = total_minutes / 60;
+                let minutes = total_minutes % 60;
                 let mut buf: [u8; 6] = *b"+00:00";
-                if min < 0 {
+                if (minutes < 0) || (hours < 0) {
                     buf[0] = b'-';
-                    min = min.abs();
                 }
-                crate::display_num_buf(2, 1, min as u32, &mut buf);
-                crate::display_num_buf(2, 4, sec as u32, &mut buf);
+                crate::display_num_buf(2, 1, hours.abs() as u32, &mut buf);
+                crate::display_num_buf(2, 4, minutes.abs() as u32, &mut buf);
                 f.write_str(std::str::from_utf8(&buf[..]).unwrap())?;
             }
         }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -749,6 +749,14 @@ fn datetime_tz_negative_2212() {
     let dt = DateTime::parse_str("2020-01-01T12:13:14−02:15").unwrap();
     assert_eq!(dt.time.tz_offset, Some(-8100));
     assert_eq!(dt.to_string(), "2020-01-01T12:13:14-02:15");
+
+    let dt = DateTime::parse_str("2020-01-01T12:13:14−00:01").unwrap();
+    assert_eq!(dt.time.tz_offset, Some(-60));
+    assert_eq!(dt.to_string(), "2020-01-01T12:13:14-00:01");
+
+    let dt = DateTime::parse_str("2020-01-01T12:13:14−01:00").unwrap();
+    assert_eq!(dt.time.tz_offset, Some(-3600));
+    assert_eq!(dt.to_string(), "2020-01-01T12:13:14-01:00");
 }
 
 #[test]


### PR DESCRIPTION
Fix https://github.com/pydantic/pydantic/issues/8964

Our logic was a bit off in terms of converting negative timezone offsets -> the corresponding minute / second string representations.