### PR TITLE
raise `DateNotExact` error for millisecond timestamps

### DIFF
--- a/src/date.rs
+++ b/src/date.rs
@@ -206,9 +206,9 @@ impl Date {
     /// assert_eq!(d.to_string(), "2022-06-07");
     /// ```
     pub fn from_timestamp(timestamp: i64, require_exact: bool) -> Result<Self, ParseError> {
-        let (timestamp_second, micros) = Self::timestamp_watershed(timestamp)?;
-        let (d, seconds) = Self::from_timestamp_calc(timestamp_second)?;
-        if require_exact && (seconds != 0 || micros != 0) {
+        let (seconds, microseconds) = Self::timestamp_watershed(timestamp)?;
+        let (d, remaining_seconds) = Self::from_timestamp_calc(seconds)?;
+        if require_exact && (remaining_seconds != 0 || microseconds != 0) {
             return Err(ParseError::DateNotExact);
         }
         Ok(d)

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -400,9 +400,7 @@ impl DateTime {
                 .ok_or(ParseError::TimeTooLarge)?;
             total_microsecond %= 1_000_000;
         }
-        let date = Date::from_timestamp_calc(second)?;
-        // rem_euclid since if `timestamp_second = -100`, we want `time_second = 86300` (e.g. `86400 - 100`)
-        let time_second = second.rem_euclid(86_400) as u32;
+        let (date, time_second) = Date::from_timestamp_calc(second)?;
         Ok(Self {
             date,
             time: Time::from_timestamp_with_config(time_second, total_microsecond, config)?,

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -230,12 +230,22 @@ fn date_comparison() {
 }
 
 #[test]
-fn date_timestamp() {
+fn date_timestamp_exact() {
     let d = Date::from_timestamp(1_654_560_000, true).unwrap();
     assert_eq!(d.to_string(), "2022-06-07");
     assert_eq!(d.timestamp(), 1_654_560_000);
 
     match Date::from_timestamp(1_654_560_001, true) {
+        Ok(d) => panic!("unexpectedly valid, {d}"),
+        Err(e) => assert_eq!(e, ParseError::DateNotExact),
+    }
+
+    // milliseconds
+    let d = Date::from_timestamp(1_654_560_000_000, true).unwrap();
+    assert_eq!(d.to_string(), "2022-06-07");
+    assert_eq!(d.timestamp(), 1_654_560_000);
+
+    match Date::from_timestamp(1_654_560_000_001, true) {
         Ok(d) => panic!("unexpectedly valid, {d}"),
         Err(e) => assert_eq!(e, ParseError::DateNotExact),
     }


### PR DESCRIPTION
Split from #65 

Reading the code it seemed to be an obvious deficiency that only second timestamps were checked for exactness and millisecond timestamps would just ignore the millisecond portion.