### PR TITLE
Fix overflow duration error messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "speedate"
 authors = ["Samuel Colvin <s@muelcolvin.com>"]
-version = "0.14.1"
+version = "0.14.2"
 edition = "2021"
 description = "Fast and simple datetime, date, time and duration parsing"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,9 +134,9 @@ pub enum ParseError {
     DurationInvalidDays,
     /// a numeric value in the duration is too large
     DurationValueTooLarge,
-    /// durations may not exceed 999,999,999 days
+    /// durations may not exceed 999,999,999 hours
     DurationHourValueTooLarge,
-    /// durations hours must less than 1,000,000,000
+    /// durations may not exceed 999,999,999 days
     DurationDaysTooLarge,
     /// dates before 1600 are not supported as unix timestamps
     DateTooSmall,


### PR DESCRIPTION
Fix minor error introduced in https://github.com/pydantic/speedate/pull/64/files#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759, and then prep for a patch release with this change