### PR TITLE
Support dates only starting from 1AC

### DIFF
--- a/fuzz/fuzz_targets/datetime_from_timestamp.rs
+++ b/fuzz/fuzz_targets/datetime_from_timestamp.rs
@@ -20,7 +20,7 @@ fn check_timestamp(timestamp: i64, microseconds: u32) {
 
         if let Some(mut chrono_dt) = NaiveDateTime::from_timestamp_opt(chrono_seconds, chrono_nano) {
             let year = chrono_dt.year();
-            if year >= 0 && year <= 9999 {
+            if year >= 1 && year <= 9999 {
                 let dt = match DateTime::from_timestamp(timestamp, microseconds) {
                     Ok(dt) => dt,
                     Err(e) => panic!(

--- a/src/date.rs
+++ b/src/date.rs
@@ -59,8 +59,10 @@ impl FromStr for Date {
 pub(crate) const MS_WATERSHED: i64 = 20_000_000_000;
 // 9999-12-31T23:59:59 as a unix timestamp, used as max allowed value below
 const UNIX_9999: i64 = 253_402_300_799;
-// 0000-01-01T00:00:00+00:00 as a unix timestamp, used as min allowed value below
+// 0000-01-01T00:00:00+00:00 as a unix timestamp
 const UNIX_0000: i64 = -62_167_219_200;
+// 0001-01-01T00:00:00+00:00 as a unix timestamp, used as min allowed value below
+const UNIX_0001: i64 = -62_135_596_800;
 
 impl Date {
     /// Parse a date from a string using RFC 3339 format
@@ -182,14 +184,14 @@ impl Date {
     ///
     /// ("Unix Timestamp" means number of seconds or milliseconds since 1970-01-01)
     ///
-    /// Input must be between `-62,167,219,200,000` (`0000-01-01`) and `253,402,300,799,000` (`9999-12-31`) inclusive.
+    /// Input must be between `-62,135,596,800,000` (`0001-01-01`) and `253,402,300,799,000` (`9999-12-31`) inclusive.
     ///
     /// If the absolute value is > 2e10 (`20,000,000,000`) it is interpreted as being in milliseconds.
     ///
     /// That means:
     /// * `20,000,000,000` is `2603-10-11`
     /// * `20,000,000,001` is `1970-08-20`
-    /// * `-62,167,219,200,001` gives an error - `DateTooSmall` as it would be before 0000-01-01
+    /// * `-62,135,596,800,001` gives an error - `DateTooSmall` as it would be before 0001-01-01
     /// * `-20,000,000,001` is `1969-05-14`
     /// * `-20,000,000,000` is `1336-03-23`
     ///
@@ -285,7 +287,7 @@ impl Date {
     }
 
     pub(crate) fn from_timestamp_calc(timestamp_second: i64) -> Result<(Self, u32), ParseError> {
-        if timestamp_second < UNIX_0000 {
+        if timestamp_second < UNIX_0001 {
             return Err(ParseError::DateTooSmall);
         }
         if timestamp_second > UNIX_9999 {

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -383,7 +383,7 @@ impl DateTime {
     ///
     /// ("Unix Timestamp" means number of seconds or milliseconds since 1970-01-01)
     ///
-    /// Input must be between `-11_676_096_000` (`1600-01-01T00:00:00`) and
+    /// Input must be between `-62_135_596_800` (`0001-01-01T00:00:00`) and
     /// `253_402_300_799_000` (`9999-12-31T23:59:59.999999`) inclusive.
     ///
     /// If the absolute value is > 2e10 (`20_000_000_000`) it is interpreted as being in milliseconds.
@@ -391,7 +391,7 @@ impl DateTime {
     /// That means:
     /// * `20_000_000_000` is `2603-10-11T11:33:20`
     /// * `20_000_000_001` is `1970-08-20T11:33:20.001`
-    /// * `-20_000_000_000` gives an error - `DateTooSmall` as it would be before 1600
+    /// * `-62_135_596_801` gives an error - `DateTooSmall` as it would be before 0001
     /// * `-20_000_000_001` is `1969-05-14T12:26:39.999`
     ///
     /// # Arguments
@@ -440,14 +440,14 @@ impl DateTime {
     ///
     /// ("Unix Timestamp" means number of seconds or milliseconds since 1970-01-01)
     ///
-    /// Input must be between `-62,167,219,200,000` (`0000-01-01`) and `253,402,300,799,000` (`9999-12-31`) inclusive.
+    /// Input must be between `-62,135,596,800,000` (`0001-01-01`) and `253,402,300,799,000` (`9999-12-31`) inclusive.
     ///
     /// If the absolute value is > 2e10 (`20,000,000,000`) it is interpreted as being in milliseconds.
     ///
     /// That means:
     /// * `20,000,000,000` is `2603-10-11`
     /// * `20,000,000,001` is `1970-08-20`
-    /// * `-62,167,219,200,001` gives an error - `DateTooSmall` as it would be before 0000-01-01
+    /// * `-62,135,596,800,001` gives an error - `DateTooSmall` as it would be before 0001-01-01
     /// * `-20,000,000,001` is `1969-05-14`
     /// * `-20,000,000,000` is `1336-03-23`
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,7 +138,7 @@ pub enum ParseError {
     DurationHourValueTooLarge,
     /// durations may not exceed 999,999,999 days
     DurationDaysTooLarge,
-    /// dates before 0000 are not supported as unix timestamps
+    /// dates before 0001 are not supported as unix timestamps
     DateTooSmall,
     /// dates after 9999 are not supported as unix timestamps
     DateTooLarge,

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -148,7 +148,7 @@ param_tests! {
     date_special_404ad_leap: ok => "0404-02-29", "0404-02-29";
     date_unix_before_watershed: ok => "19999872000", "2603-10-10";
     date_unix_after_watershed: ok => "20044800000", "1970-08-21";
-    date_unix_too_low: err => "-62167219200001", DateTooSmall;
+    date_unix_too_low: err => "-62135596800001", DateTooSmall;
 }
 
 #[test]
@@ -161,9 +161,9 @@ fn date_from_timestamp_extremes() {
         Ok(dt) => panic!("unexpectedly valid, {dt}"),
         Err(e) => assert_eq!(e, ParseError::DateTooLarge),
     }
-    let d = Date::from_timestamp(-62_167_219_200_000, false).unwrap();
-    assert_eq!(d.to_string(), "0000-01-01");
-    match Date::from_timestamp(-62_167_219_200_001, false) {
+    let d = Date::from_timestamp(-62_135_596_800_000, false).unwrap();
+    assert_eq!(d.to_string(), "0001-01-01");
+    match Date::from_timestamp(-62_135_596_800_001, false) {
         Ok(dt) => panic!("unexpectedly valid, {dt}"),
         Err(e) => assert_eq!(e, ParseError::DateTooSmall),
     }
@@ -177,14 +177,14 @@ fn date_from_timestamp_extremes() {
 
 #[test]
 fn date_from_timestamp_special_dates() {
-    let d = Date::from_timestamp(-11_676_096_000 + 1000, false).unwrap();
-    assert_eq!(d.to_string(), "1600-01-01");
+    let d = Date::from_timestamp(-62_135_596_800_000 + 1000, false).unwrap();
+    assert_eq!(d.to_string(), "0001-01-01");
     // check if there is any error regarding offset at the second level
     // and if rounding down works
-    let d = Date::from_timestamp(-11_676_096_000 + 86399, false).unwrap();
-    assert_eq!(d.to_string(), "1600-01-01");
-    let d = Date::from_timestamp(-11_673_417_600, false).unwrap();
-    assert_eq!(d.to_string(), "1600-02-01");
+    let d = Date::from_timestamp(-62_135_596_800_000 + 86399, false).unwrap();
+    assert_eq!(d.to_string(), "0001-01-01");
+    let d = Date::from_timestamp(-62_132_918_400_000, false).unwrap();
+    assert_eq!(d.to_string(), "0001-02-01");
 }
 
 #[test]
@@ -468,8 +468,8 @@ fn datetime_from_timestamp_specific() {
     assert_eq!(dt.to_string(), "1970-01-01T00:00:00.667444");
     let dt = DateTime::from_timestamp(32_503_680_000_000, 0).unwrap();
     assert_eq!(dt.to_string(), "3000-01-01T00:00:00");
-    let dt = DateTime::from_timestamp(-11_676_096_000, 0).unwrap();
-    assert_eq!(dt.to_string(), "1600-01-01T00:00:00");
+    let dt = DateTime::from_timestamp(-62_135_596_800_000, 0).unwrap();
+    assert_eq!(dt.to_string(), "0001-01-01T00:00:00");
     let dt = DateTime::from_timestamp(1_095_216_660_480, 3221223).unwrap();
     assert_eq!(dt.to_string(), "2004-09-15T02:51:03.701223");
 


### PR DESCRIPTION
Fixes https://github.com/pydantic/pydantic/issues/10967

Python has `datetime.MINYEAR = 1` [source](https://docs.python.org/3/library/datetime.html#datetime.MINYEAR). It is not possible to create `datetime.date` or `datetime.datetime` that has year smaller than 1.

This is the first time I have even looked at Rust code, thus there might be a lot of mistakes.

Thank you @changhc for providing an changelog example in #77