### PR TITLE
optimize `float_parse_bytes`

### DIFF
--- a/benches/main.rs
+++ b/benches/main.rs
@@ -123,7 +123,7 @@ fn compare_timestamp_ok_chrono(bench: &mut Bencher) {
     use chrono::{Datelike, Timelike};
     let ts = black_box(1654617803);
     bench.iter(|| {
-        let dt = chrono::NaiveDateTime::from_timestamp_opt(ts, 0).unwrap();
+        let dt = chrono::DateTime::from_timestamp(ts, 0).unwrap();
         black_box((
             dt.year(),
             dt.month(),

--- a/src/numbers.rs
+++ b/src/numbers.rs
@@ -59,52 +59,81 @@ pub fn float_parse_str(s: &str) -> IntFloat {
 /// Parse bytes as an float.
 pub fn float_parse_bytes(s: &[u8]) -> IntFloat {
     let (neg, first_digit, digits) = match s {
-        [b'-', first, digits @ ..] => (true, first, digits),
-        [b'+', first, digits @ ..] | [first, digits @ ..] => (false, first, digits),
-        _ => return IntFloat::Err,
+        [b'-', first, digits @ ..] => (true, *first, digits),
+        [b'+', first, digits @ ..] | [first, digits @ ..] => (false, *first, digits),
+        [] => return IntFloat::Err,
     };
 
-    let mut int_part = match first_digit {
-        b'0' => 0,
-        b'1'..=b'9' => (first_digit & 0x0f) as i64,
-        _ => return IntFloat::Err,
-    };
+    let int_part = DECODE_MAP[first_digit as usize];
 
-    let mut found_dot = false;
+    if int_part == ERR {
+        return IntFloat::Err;
+    }
 
-    let mut bytes = digits.iter().copied();
+    let mut int_part = int_part as i64;
 
-    for digit in bytes.by_ref() {
-        match digit {
-            b'0'..=b'9' => {
-                int_part = match int_part.checked_mul(10) {
-                    Some(i) => i,
-                    None => return IntFloat::Err,
-                };
-                int_part = match int_part.checked_add((digit & 0x0f) as i64) {
-                    Some(i) => i,
-                    None => return IntFloat::Err,
-                };
-            }
-            b'.' => {
-                found_dot = true;
-                break;
-            }
-            _ => return IntFloat::Err,
+    for &digit in digits {
+        let value = DECODE_MAP[digit as usize];
+
+        debug_assert!(value <= 9 || value == ERR);
+
+        if value == ERR {
+            return parse_possible_float(s, digit);
+        }
+
+        int_part = int_part.wrapping_mul(10);
+        int_part = int_part.wrapping_add(value as i64);
+
+        // if overflow occurred, return an error
+        if int_part < 0 {
+            return IntFloat::Err;
         }
     }
 
-    if found_dot {
-        let options = ParseFloatOptions::new();
-        match f64::from_lexical_with_options::<{ lexical_format::STANDARD }>(s, &options) {
-            Ok(v) => IntFloat::Float(v),
-            Err(_) => IntFloat::Err,
-        }
-    } else if neg {
+    if neg {
         IntFloat::Int(-int_part)
     } else {
         IntFloat::Int(int_part)
     }
+}
+
+const ERR: u8 = 0xff;
+
+#[rustfmt::skip]
+static DECODE_MAP: [u8; 256] = {
+    const __: u8 = ERR;
+    [
+        //   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 0
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 1
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 2
+         0,  1,  2,  3,  4,  5,  6,  7,  8,  9, __, __, __, __, __, __, // 3
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 4
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 5
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 6
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 7
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 8
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 9
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // A
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // B
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // C
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // D
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // E
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // F
+    ]
+};
+
+#[inline(never)] // avoid making the hot loop large
+fn parse_possible_float(s: &[u8], current_digit: u8) -> IntFloat {
+    if current_digit != b'.' {
+        return IntFloat::Err;
+    }
+
+    static OPTIONS: ParseFloatOptions = ParseFloatOptions::new();
+    return match f64::from_lexical_with_options::<{ lexical_format::STANDARD }>(s, &OPTIONS) {
+        Ok(v) => IntFloat::Float(v),
+        Err(_) => IntFloat::Err,
+    };
 }
 
 /// Count the number of decimal places in a byte slice.

--- a/src/numbers.rs
+++ b/src/numbers.rs
@@ -130,10 +130,10 @@ fn parse_possible_float(s: &[u8], current_digit: u8) -> IntFloat {
     }
 
     static OPTIONS: ParseFloatOptions = ParseFloatOptions::new();
-    return match f64::from_lexical_with_options::<{ lexical_format::STANDARD }>(s, &OPTIONS) {
+    match f64::from_lexical_with_options::<{ lexical_format::STANDARD }>(s, &OPTIONS) {
         Ok(v) => IntFloat::Float(v),
         Err(_) => IntFloat::Err,
-    };
+    }
 }
 
 /// Count the number of decimal places in a byte slice.

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -2,7 +2,7 @@ use std::fs::File;
 use std::io::Read;
 use std::str::FromStr;
 
-use chrono::{Datelike, FixedOffset as ChronoFixedOffset, NaiveDate, NaiveDateTime, Timelike, Utc as ChronoUtc};
+use chrono::{Datelike, FixedOffset as ChronoFixedOffset, NaiveDate, Timelike, Utc as ChronoUtc};
 use strum::EnumMessage;
 
 use speedate::{
@@ -215,7 +215,7 @@ fn date_from_timestamp_milliseconds() {
 }
 
 fn try_date_timestamp(ts: i64, check_timestamp: bool) {
-    let chrono_date = NaiveDateTime::from_timestamp_opt(ts, 0).unwrap().date();
+    let chrono_date = chrono::DateTime::from_timestamp(ts, 0).unwrap().date_naive();
     let d = Date::from_timestamp(ts, false).unwrap();
     // println!("{} => {:?}", ts, d);
     assert_eq!(
@@ -283,7 +283,7 @@ macro_rules! date_from_timestamp {
             #[test]
             fn [< date_from_timestamp_ $year _ $month _ $day >]() {
                 let chrono_date = NaiveDate::from_ymd_opt($year, $month, $day).unwrap();
-                let ts = chrono_date.and_hms_opt(0, 0, 0).unwrap().timestamp();
+                let ts = chrono_date.and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp();
                 let d = Date::from_timestamp(ts, false).unwrap();
                 assert_eq!(
                     d,
@@ -404,7 +404,7 @@ fn time_from_timestamp_error() {
     }
 }
 
-fn try_datetime_timestamp(chrono_dt: NaiveDateTime) {
+fn try_datetime_timestamp(chrono_dt: chrono::DateTime<ChronoUtc>) {
     let ts = chrono_dt.timestamp();
     let dt = DateTime::from_timestamp(ts, chrono_dt.nanosecond() / 1_000).unwrap();
     // println!("{} ({}) => {}", ts, chrono_dt, dt);
@@ -435,7 +435,7 @@ macro_rules! datetime_from_timestamp {
         paste::item! {
             #[test]
             fn [< datetime_from_timestamp_ $year _ $month _ $day _t_ $hour _ $minute _ $second _ $microsecond >]() {
-                let chrono_dt = NaiveDate::from_ymd_opt($year, $month, $day).unwrap().and_hms_nano_opt($hour, $minute, $second, $microsecond * 1_000).unwrap();
+                let chrono_dt = NaiveDate::from_ymd_opt($year, $month, $day).unwrap().and_hms_nano_opt($hour, $minute, $second, $microsecond * 1_000).unwrap().and_utc();
                 try_datetime_timestamp(chrono_dt);
             }
         }
@@ -455,8 +455,8 @@ datetime_from_timestamp! {
 #[test]
 fn datetime_from_timestamp_range() {
     for ts in (0..157_766_400).step_by(757) {
-        try_datetime_timestamp(NaiveDateTime::from_timestamp_opt(ts, 0).unwrap());
-        try_datetime_timestamp(NaiveDateTime::from_timestamp_opt(-ts, 0).unwrap());
+        try_datetime_timestamp(chrono::DateTime::from_timestamp(ts, 0).unwrap());
+        try_datetime_timestamp(chrono::DateTime::from_timestamp(-ts, 0).unwrap());
     }
 }
 


### PR DESCRIPTION
Noticed some opportunity while reading #81, which will help mitigate some of the new cost on floats.

Before:

```
running 1 test
test parse_timestamp_str             ... bench:         375.03 ns/iter (+/- 15.90)

test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured; 18 filtered out; finished in 0.29s
```

After:

```
running 1 test
test parse_timestamp_str             ... bench:         327.23 ns/iter (+/- 19.36)

test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured; 18 filtered out; finished in 0.22s
```