### PR TITLE
Support explicitly parsing timestamps as seconds/milliseconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ The following formats are supported:
   positive and negative durations respectively
 
 In addition, unix timestamps (both seconds and milliseconds) can be used to create dates and datetimes.
+The interpretation of numeric timestamps can be controlled via the `TimestampUnit` configuration.
+By default the unit is inferred from the length of the number, but you can set it explicitly using a
+`DateConfig` or `DateTimeConfig`.
 
 See [the documentation](https://docs.rs/speedate/latest/speedate/index.html#structs) for each struct for more details.
 
@@ -66,13 +69,19 @@ assert_eq!(dt.to_string(), "2022-01-01T12:13:14Z");
 To control the specifics of time parsing you can use provide a `TimeConfig`:
 
 ```rust
-use speedate::{DateTime, Date, Time, TimeConfig, MicrosecondsPrecisionOverflowBehavior};
+use speedate::{
+    DateTime, Date, Time, DateTimeConfig, TimeConfig,
+    MicrosecondsPrecisionOverflowBehavior, TimestampUnit,
+};
 let dt = DateTime::parse_bytes_with_config(
     "1689102037.5586429".as_bytes(),
-    &TimeConfig::builder()
-        .unix_timestamp_offset(Some(0))
-        .microseconds_precision_overflow_behavior(MicrosecondsPrecisionOverflowBehavior::Truncate)
-        .build(),
+    &DateTimeConfig {
+        timestamp_unit: TimestampUnit::Infer,
+        time_config: TimeConfig::builder()
+            .unix_timestamp_offset(Some(0))
+            .microseconds_precision_overflow_behavior(MicrosecondsPrecisionOverflowBehavior::Truncate)
+            .build(),
+    },
 ).unwrap();
 assert_eq!(
     dt,
@@ -92,6 +101,32 @@ assert_eq!(
     }
 );
 assert_eq!(dt.to_string(), "2023-07-11T19:00:37.558643Z");
+```
+
+The `timestamp_unit` field on `DateConfig` and `DateTimeConfig` controls how
+numeric timestamps are interpreted. By default, the unit is inferred based on
+the value's length. You can force seconds or milliseconds parsing:
+
+```rust
+use speedate::{DateTime, DateTimeConfig, TimestampUnit, TimeConfig};
+
+let cfg = DateTimeConfig {
+    timestamp_unit: TimestampUnit::Millisecond,
+    time_config: TimeConfig::builder().unix_timestamp_offset(Some(0)).build(),
+};
+
+let dt = DateTime::parse_bytes_with_config(b"1641039194000", &cfg).unwrap();
+assert_eq!(dt.to_string(), "2022-01-01T12:13:14Z");
+```
+
+Likewise, you can configure `Date` parsing:
+
+```rust
+use speedate::{Date, DateConfig, TimestampUnit};
+
+let cfg = DateConfig { timestamp_unit: TimestampUnit::Second };
+let d = Date::parse_bytes_with_config(b"1640995200", &cfg).unwrap();
+assert_eq!(d.to_string(), "2022-01-01");
 ```
 
 ## Performance

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,57 @@
+use crate::{ConfigError, time::TimeConfig};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub enum TimestampUnit {
+    /// Interpret as seconds since the UNIX epoch.
+    Second,
+    /// Interpret as milliseconds since the UNIX epoch.
+    Millisecond,
+    /// Let the parser infer units based on value length.
+    #[default]
+    Infer,
+}
+
+impl TryFrom<&str> for TimestampUnit {
+    type Error = ConfigError;
+    fn try_from(value: &str) -> Result<Self, ConfigError> {
+        match value.to_lowercase().as_str() {
+            "s" => Ok(Self::Second),
+            "ms" => Ok(Self::Millisecond),
+            "infer" => Ok(Self::Infer),
+            _ => Err(ConfigError::UnknownTimestampUnitString),
+        }
+    }
+}
+
+/// Configuration for parsing `Date`.
+#[derive(Debug, Clone)]
+pub struct DateConfig {
+    /// How to interpret numeric timestamps (seconds, milliseconds, etc.).
+    pub timestamp_unit: TimestampUnit,
+}
+
+impl Default for DateConfig {
+    fn default() -> Self {
+        DateConfig {
+            timestamp_unit: TimestampUnit::Infer,
+        }
+    }
+}
+
+/// Configuration for parsing `DateTime`.
+#[derive(Debug, Clone)]
+pub struct DateTimeConfig {
+    /// How to interpret numeric timestamps (seconds, milliseconds, etc.).
+    pub timestamp_unit: TimestampUnit,
+    /// Configuration used when parsing the time component.
+    pub time_config: TimeConfig,
+}
+
+impl Default for DateTimeConfig {
+    fn default() -> Self {
+        DateTimeConfig {
+            timestamp_unit: TimestampUnit::Infer,
+            time_config: TimeConfig::default(),
+        }
+    }
+}

--- a/src/date.rs
+++ b/src/date.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 
 use crate::numbers::int_parse_bytes;
 use crate::{get_digit_unchecked, DateTime, ParseError};
+use crate::config::{DateConfig, TimestampUnit};
 
 /// A Date
 ///
@@ -114,6 +115,12 @@ impl Date {
         Self::parse_bytes(str.as_bytes())
     }
 
+    /// As with [`Date::parse_str`] but with a [`DateConfig`].
+    #[inline]
+    pub fn parse_str_with_config(str: &str, config: &DateConfig) -> Result<Self, ParseError> {
+        Self::parse_bytes_with_config(str.as_bytes(), config)
+    }
+
     /// Parse a date from bytes using RFC 3339 format
     ///
     /// # Arguments
@@ -169,10 +176,16 @@ impl Date {
     /// ```
     #[inline]
     pub fn parse_bytes(bytes: &[u8]) -> Result<Self, ParseError> {
+        Self::parse_bytes_with_config(bytes, &DateConfig::default())
+    }
+
+    /// Same as [`Date::parse_bytes`] but with a [`DateConfig`].
+    #[inline]
+    pub fn parse_bytes_with_config(bytes: &[u8], config: &DateConfig) -> Result<Self, ParseError> {
         match Self::parse_bytes_rfc3339(bytes) {
             Ok(d) => Ok(d),
             Err(e) => match int_parse_bytes(bytes) {
-                Some(int) => Self::from_timestamp(int, true),
+                Some(int) => Self::from_timestamp(int, true, config),
                 None => Err(e),
             },
         }
@@ -201,13 +214,29 @@ impl Date {
     /// # Examples
     ///
     /// ```
-    /// use speedate::Date;
+    /// use speedate::{Date, DateConfig};
     ///
-    /// let d = Date::from_timestamp(1_654_560_000, true).unwrap();
+    /// let d = Date::from_timestamp(1_654_560_000, true, &DateConfig::default()).unwrap();
     /// assert_eq!(d.to_string(), "2022-06-07");
     /// ```
-    pub fn from_timestamp(timestamp: i64, require_exact: bool) -> Result<Self, ParseError> {
-        let (seconds, microseconds) = Self::timestamp_watershed(timestamp)?;
+    pub fn from_timestamp(
+        timestamp: i64,
+        require_exact: bool,
+        config: &DateConfig,
+    ) -> Result<Self, ParseError> {
+        let (seconds, microseconds) = match config.timestamp_unit {
+            TimestampUnit::Second => (timestamp, 0),
+            TimestampUnit::Millisecond => {
+                let mut seconds = timestamp / 1_000;
+                let mut microseconds = ((timestamp % 1_000) * 1000) as i32;
+                if microseconds < 0 {
+                    seconds -= 1;
+                    microseconds += 1_000_000;
+                }
+                (seconds, microseconds as u32)
+            }
+            TimestampUnit::Infer => Self::timestamp_watershed(timestamp)?,
+        };
         let (d, remaining_seconds) = Self::from_timestamp_calc(seconds)?;
         if require_exact && (remaining_seconds != 0 || microseconds != 0) {
             return Err(ParseError::DateNotExact);
@@ -229,6 +258,20 @@ impl Date {
         let days =
             (self.year as i64) * 365 + (self.ordinal_day() - 1) as i64 + intervening_leap_years(self.year as i64);
         days * 86400 + UNIX_0000
+    }
+
+    /// Unix timestamp in milliseconds (number of milliseconds between self and 1970-01-01)
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use speedate::Date;
+    ///
+    /// let d = Date::parse_str("2022-06-07").unwrap();
+    /// assert_eq!(d.timestamp_ms(), 1_654_560_000_000);
+    /// ```
+    pub fn timestamp_ms(&self) -> i64 {
+        self.timestamp() * 1000
     }
 
     /// Current date. Internally, this uses [DateTime::now].
@@ -283,6 +326,7 @@ impl Date {
         }
         Ok((seconds, microseconds as u32))
     }
+
 
     pub(crate) fn from_timestamp_calc(timestamp_second: i64) -> Result<(Self, u32), ParseError> {
         if timestamp_second < UNIX_0000 {

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -318,6 +318,12 @@ impl Duration {
         sign * (self.day as i64 * 86400 + self.second as i64)
     }
 
+    /// Total number of milliseconds in the duration (days + seconds) with sign.
+    #[inline]
+    pub fn signed_total_ms(&self) -> i64 {
+        self.signed_total_seconds() * 1000 + (self.signed_microseconds() as i64) / 1000
+    }
+
     /// Microseconds in the duration with sign based on `self.positive`
     #[inline]
     pub fn signed_microseconds(&self) -> i32 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,11 +9,13 @@ mod datetime;
 mod duration;
 mod numbers;
 mod time;
+mod config;
 
 pub use date::Date;
 pub use datetime::DateTime;
 pub use duration::Duration;
 pub use time::{MicrosecondsPrecisionOverflowBehavior, Time, TimeConfig, TimeConfigBuilder};
+pub use config::{TimestampUnit, DateConfig, DateTimeConfig};
 
 pub use numbers::{float_parse_bytes, float_parse_str, int_parse_bytes, int_parse_str, IntFloat};
 
@@ -151,6 +153,8 @@ pub enum ParseError {
 pub enum ConfigError {
     // SecondsPrecisionOverflowBehavior string representation, must be one of "error" or "truncate"
     UnknownMicrosecondsPrecisionOverflowBehaviorString,
+    // TimestampUnit string representation, must be one of "s", "ms" or "infer"
+    UnknownTimestampUnitString,
 }
 
 /// Used internally to write numbers to a buffer for `Display` of speedate types

--- a/src/time.rs
+++ b/src/time.rs
@@ -392,6 +392,20 @@ impl Time {
         total_seconds
     }
 
+    /// Get the total milliseconds of the time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use speedate::Time;
+    ///
+    /// let d = Time::parse_str("12:13:14.123456").unwrap();
+    /// assert_eq!(d.total_ms(), (12 * 3600 + 13 * 60 + 14) * 1000 + 123);
+    /// ```
+    pub fn total_ms(&self) -> u32 {
+        self.total_seconds() * 1000 + self.microsecond / 1000
+    }
+
     /// Clone the time and set a new timezone offset.
     ///
     /// The returned time will represent a different point in time since the timezone offset is changed without

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -8,6 +8,7 @@ use strum::EnumMessage;
 use speedate::{
     float_parse_bytes, float_parse_str, int_parse_bytes, int_parse_str, Date, DateTime, Duration, IntFloat,
     MicrosecondsPrecisionOverflowBehavior, ParseError, Time, TimeConfig, TimeConfigBuilder,
+    DateTimeConfig, DateConfig, TimestampUnit,
 };
 
 /// macro for expected values
@@ -153,23 +154,23 @@ param_tests! {
 
 #[test]
 fn date_from_timestamp_extremes() {
-    match Date::from_timestamp(i64::MIN, false) {
+    match Date::from_timestamp(i64::MIN, false, &DateConfig::default()) {
         Ok(dt) => panic!("unexpectedly valid, {dt}"),
         Err(e) => assert_eq!(e, ParseError::DateTooSmall),
     }
-    match Date::from_timestamp(i64::MAX, false) {
+    match Date::from_timestamp(i64::MAX, false, &DateConfig::default()) {
         Ok(dt) => panic!("unexpectedly valid, {dt}"),
         Err(e) => assert_eq!(e, ParseError::DateTooLarge),
     }
-    let d = Date::from_timestamp(-62_167_219_200_000, false).unwrap();
+    let d = Date::from_timestamp(-62_167_219_200_000, false, &DateConfig::default()).unwrap();
     assert_eq!(d.to_string(), "0000-01-01");
-    match Date::from_timestamp(-62_167_219_200_001, false) {
+    match Date::from_timestamp(-62_167_219_200_001, false, &DateConfig::default()) {
         Ok(dt) => panic!("unexpectedly valid, {dt}"),
         Err(e) => assert_eq!(e, ParseError::DateTooSmall),
     }
-    let d = Date::from_timestamp(253_402_300_799_000, false).unwrap();
+    let d = Date::from_timestamp(253_402_300_799_000, false, &DateConfig::default()).unwrap();
     assert_eq!(d.to_string(), "9999-12-31");
-    match Date::from_timestamp(253_402_300_800_000, false) {
+    match Date::from_timestamp(253_402_300_800_000, false, &DateConfig::default()) {
         Ok(dt) => panic!("unexpectedly valid, {dt}"),
         Err(e) => assert_eq!(e, ParseError::DateTooLarge),
     }
@@ -177,31 +178,31 @@ fn date_from_timestamp_extremes() {
 
 #[test]
 fn date_from_timestamp_special_dates() {
-    let d = Date::from_timestamp(-11_676_096_000 + 1000, false).unwrap();
+    let d = Date::from_timestamp(-11_676_096_000 + 1000, false, &DateConfig::default()).unwrap();
     assert_eq!(d.to_string(), "1600-01-01");
     // check if there is any error regarding offset at the second level
     // and if rounding down works
-    let d = Date::from_timestamp(-11_676_096_000 + 86399, false).unwrap();
+    let d = Date::from_timestamp(-11_676_096_000 + 86399, false, &DateConfig::default()).unwrap();
     assert_eq!(d.to_string(), "1600-01-01");
-    let d = Date::from_timestamp(-11_673_417_600, false).unwrap();
+    let d = Date::from_timestamp(-11_673_417_600, false, &DateConfig::default()).unwrap();
     assert_eq!(d.to_string(), "1600-02-01");
 }
 
 #[test]
 fn date_watershed() {
-    let dt = Date::from_timestamp(20_000_000_000, false).unwrap();
+    let dt = Date::from_timestamp(20_000_000_000, false, &DateConfig::default()).unwrap();
     assert_eq!(dt.to_string(), "2603-10-11");
-    let dt = Date::from_timestamp(20_000_000_001, false).unwrap();
+    let dt = Date::from_timestamp(20_000_000_001, false, &DateConfig::default()).unwrap();
     assert_eq!(dt.to_string(), "1970-08-20");
-    let dt = Date::from_timestamp(-20_000_000_000, false).unwrap();
+    let dt = Date::from_timestamp(-20_000_000_000, false, &DateConfig::default()).unwrap();
     assert_eq!(dt.to_string(), "1336-03-23");
-    let dt = Date::from_timestamp(-20_000_000_001, false).unwrap();
+    let dt = Date::from_timestamp(-20_000_000_001, false, &DateConfig::default()).unwrap();
     assert_eq!(dt.to_string(), "1969-05-14");
 }
 
 #[test]
 fn date_from_timestamp_milliseconds() {
-    let d1 = Date::from_timestamp(1_654_472_524, false).unwrap();
+    let d1 = Date::from_timestamp(1_654_472_524, false, &DateConfig::default()).unwrap();
     assert_eq!(
         d1,
         Date {
@@ -210,13 +211,19 @@ fn date_from_timestamp_milliseconds() {
             day: 5
         }
     );
-    let d2 = Date::from_timestamp(1_654_472_524_000, false).unwrap();
+    let d2 = Date::from_timestamp(1_654_472_524_000, false, &DateConfig::default()).unwrap();
     assert_eq!(d2, d1);
+}
+
+#[test]
+fn date_timestamp_ms_method() {
+    let d = Date::parse_str("2022-06-07").unwrap();
+    assert_eq!(d.timestamp_ms(), 1_654_560_000_000);
 }
 
 fn try_date_timestamp(ts: i64, check_timestamp: bool) {
     let chrono_date = chrono::DateTime::from_timestamp(ts, 0).unwrap().date_naive();
-    let d = Date::from_timestamp(ts, false).unwrap();
+    let d = Date::from_timestamp(ts, false, &DateConfig::default()).unwrap();
     // println!("{} => {:?}", ts, d);
     assert_eq!(
         d,
@@ -256,21 +263,21 @@ fn date_comparison() {
 
 #[test]
 fn date_timestamp_exact() {
-    let d = Date::from_timestamp(1_654_560_000, true).unwrap();
+    let d = Date::from_timestamp(1_654_560_000, true, &DateConfig::default()).unwrap();
     assert_eq!(d.to_string(), "2022-06-07");
     assert_eq!(d.timestamp(), 1_654_560_000);
 
-    match Date::from_timestamp(1_654_560_001, true) {
+    match Date::from_timestamp(1_654_560_001, true, &DateConfig::default()) {
         Ok(d) => panic!("unexpectedly valid, {d}"),
         Err(e) => assert_eq!(e, ParseError::DateNotExact),
     }
 
     // milliseconds
-    let d = Date::from_timestamp(1_654_560_000_000, true).unwrap();
+    let d = Date::from_timestamp(1_654_560_000_000, true, &DateConfig::default()).unwrap();
     assert_eq!(d.to_string(), "2022-06-07");
     assert_eq!(d.timestamp(), 1_654_560_000);
 
-    match Date::from_timestamp(1_654_560_000_001, true) {
+    match Date::from_timestamp(1_654_560_000_001, true, &DateConfig::default()) {
         Ok(d) => panic!("unexpectedly valid, {d}"),
         Err(e) => assert_eq!(e, ParseError::DateNotExact),
     }
@@ -284,7 +291,7 @@ macro_rules! date_from_timestamp {
             fn [< date_from_timestamp_ $year _ $month _ $day >]() {
                 let chrono_date = NaiveDate::from_ymd_opt($year, $month, $day).unwrap();
                 let ts = chrono_date.and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp();
-                let d = Date::from_timestamp(ts, false).unwrap();
+                let d = Date::from_timestamp(ts, false, &DateConfig::default()).unwrap();
                 assert_eq!(
                     d,
                     Date {
@@ -475,7 +482,7 @@ fn datetime_from_timestamp_specific() {
 
     let d = DateTime::from_timestamp(253_402_300_799_000, 999999).unwrap();
     assert_eq!(d.to_string(), "9999-12-31T23:59:59.999999");
-    match Date::from_timestamp(253_402_300_800_000, false) {
+    match Date::from_timestamp(253_402_300_800_000, false, &DateConfig::default()) {
         Ok(dt) => panic!("unexpectedly valid, {dt}"),
         Err(e) => assert_eq!(e, ParseError::DateTooLarge),
     }
@@ -626,6 +633,15 @@ fn time_total_seconds() {
 
     let t = Time::parse_str("12:13:14.999999").unwrap();
     assert_eq!(t.total_seconds(), 12 * 3600 + 13 * 60 + 14);
+}
+
+#[test]
+fn time_total_ms() {
+    let t = Time::parse_str("01:02:03.04").unwrap();
+    assert_eq!(t.total_ms(), (3600 + 2 * 60 + 3) * 1000 + 40);
+
+    let t = Time::parse_str("12:13:14.999999").unwrap();
+    assert_eq!(t.total_ms(), (12 * 3600 + 13 * 60 + 14) * 1000 + 999);
 }
 
 #[test]
@@ -821,6 +837,17 @@ fn datetime_timestamp_tz() {
     let dt_plus_1 = DateTime::parse_str("1970-01-02T00:00+01:00").unwrap();
     assert_eq!(dt_plus_1.timestamp(), 24 * 3600);
     assert_eq!(dt_plus_1.timestamp_tz(), 23 * 3600);
+}
+
+#[test]
+fn datetime_timestamp_ms_methods() {
+    let dt = DateTime::parse_str("1970-01-02T00:00:00.123Z").unwrap();
+    assert_eq!(dt.timestamp_ms(), 86_400_123);
+    assert_eq!(dt.timestamp_tz_ms(), 86_400_123);
+
+    let dt = DateTime::parse_str("1970-01-02T00:00:00.123+01:00").unwrap();
+    assert_eq!(dt.timestamp_ms(), 86_400_123);
+    assert_eq!(dt.timestamp_tz_ms(), 82_800_123);
 }
 
 #[test]
@@ -1033,6 +1060,15 @@ fn duration_total_seconds() {
 }
 
 #[test]
+fn duration_total_ms() {
+    let d = Duration::parse_str("P1DT0.5S").unwrap();
+    assert_eq!(d.signed_total_ms(), 86_400_500);
+
+    let d = Duration::parse_str("-PT1.001S").unwrap();
+    assert_eq!(d.signed_total_ms(), -1_001);
+}
+
+#[test]
 fn duration_total_seconds_neg() {
     let d = Duration::parse_str("-P1DT42.123456S").unwrap();
     assert_eq!(
@@ -1131,6 +1167,17 @@ fn duration_new_err() {
         Ok(t) => panic!("unexpectedly valid: {t:?}"),
         Err(e) => assert_eq!(e, ParseError::DurationDaysTooLarge),
     }
+}
+
+#[test]
+fn datetime_timestamp_ms_fractional() {
+    let dt = DateTime::parse_str("2022-06-07T00:00:01.111Z").unwrap();
+    assert_eq!(dt.timestamp_ms(), 1_654_560_001_111);
+    assert_eq!(dt.timestamp_tz_ms(), 1_654_560_001_111);
+
+    let dt = DateTime::parse_str("2022-06-07T00:00:01.111+02:00").unwrap();
+    assert_eq!(dt.timestamp_ms(), 1_654_560_001_111);
+    assert_eq!(dt.timestamp_tz_ms(), 1_654_552_801_111);
 }
 
 #[test]
@@ -1395,9 +1442,12 @@ fn test_time_parse_truncate_seconds() {
 fn test_datetime_parse_truncate_seconds() {
     let time = DateTime::parse_bytes_with_config(
         "2020-01-01T12:13:12.123456789".as_bytes(),
-        &(TimeConfigBuilder::new()
-            .microseconds_precision_overflow_behavior(MicrosecondsPrecisionOverflowBehavior::Truncate)
-            .build()),
+        &(DateTimeConfig {
+            timestamp_unit: TimestampUnit::Infer,
+            time_config: TimeConfigBuilder::new()
+                .microseconds_precision_overflow_behavior(MicrosecondsPrecisionOverflowBehavior::Truncate)
+                .build(),
+        }),
     )
     .unwrap();
     assert_eq!(time.to_string(), "2020-01-01T12:13:12.123456");
@@ -1429,7 +1479,10 @@ fn test_time_parse_bytes_does_not_add_offset_for_rfc3339() {
 fn test_datetime_parse_bytes_does_not_add_offset_for_rfc3339() {
     let time = DateTime::parse_bytes_with_config(
         "2020-01-01T12:13:12".as_bytes(),
-        &(TimeConfigBuilder::new().unix_timestamp_offset(Some(0)).build()),
+        &(DateTimeConfig {
+            timestamp_unit: TimestampUnit::Infer,
+            time_config: TimeConfigBuilder::new().unix_timestamp_offset(Some(0)).build(),
+        }),
     )
     .unwrap();
     assert_eq!(time.to_string(), "2020-01-01T12:13:12");
@@ -1439,10 +1492,13 @@ fn test_datetime_parse_bytes_does_not_add_offset_for_rfc3339() {
 fn test_datetime_parse_unix_timestamp_from_bytes_with_utc_offset() {
     let time = DateTime::parse_bytes_with_config(
         "1689102037.5586429".as_bytes(),
-        &(TimeConfigBuilder::new()
-            .unix_timestamp_offset(Some(0))
-            .microseconds_precision_overflow_behavior(MicrosecondsPrecisionOverflowBehavior::Truncate)
-            .build()),
+        &(DateTimeConfig {
+            timestamp_unit: TimestampUnit::Infer,
+            time_config: TimeConfigBuilder::new()
+                .unix_timestamp_offset(Some(0))
+                .microseconds_precision_overflow_behavior(MicrosecondsPrecisionOverflowBehavior::Truncate)
+                .build(),
+        }),
     )
     .unwrap();
     assert_eq!(time.to_string(), "2023-07-11T19:00:37.558643Z");
@@ -1452,10 +1508,13 @@ fn test_datetime_parse_unix_timestamp_from_bytes_with_utc_offset() {
 fn test_datetime_parse_unix_timestamp_from_bytes_as_naive() {
     let time = DateTime::parse_bytes_with_config(
         "1689102037.5586429".as_bytes(),
-        &(TimeConfigBuilder::new()
-            .unix_timestamp_offset(None)
-            .microseconds_precision_overflow_behavior(MicrosecondsPrecisionOverflowBehavior::Truncate)
-            .build()),
+        &(DateTimeConfig {
+            timestamp_unit: TimestampUnit::Infer,
+            time_config: TimeConfigBuilder::new()
+                .unix_timestamp_offset(None)
+                .microseconds_precision_overflow_behavior(MicrosecondsPrecisionOverflowBehavior::Truncate)
+                .build(),
+        }),
     )
     .unwrap();
     assert_eq!(time.to_string(), "2023-07-11T19:00:37.558643");
@@ -1507,4 +1566,58 @@ fn number_dash_err() {
     assert!(matches!(float_parse_str("+"), IntFloat::Err));
     assert!(matches!(float_parse_bytes(b"-"), IntFloat::Err));
     assert!(matches!(float_parse_bytes(b"+"), IntFloat::Err));
+}
+#[test]
+fn test_timestamp_unit_try_from() {
+    use speedate::TimestampUnit;
+    assert_eq!(TimestampUnit::try_from("s").unwrap(), TimestampUnit::Second);
+    assert_eq!(TimestampUnit::try_from("ms").unwrap(), TimestampUnit::Millisecond);
+    assert_eq!(TimestampUnit::try_from("infer").unwrap(), TimestampUnit::Infer);
+    assert!(TimestampUnit::try_from("invalid").is_err());
+}
+
+#[test]
+fn test_date_parse_timestamp_unit_second() {
+    use speedate::{Date, DateConfig, TimestampUnit};
+    let d = Date::parse_str_with_config(
+        "1640995200",
+        &DateConfig { timestamp_unit: TimestampUnit::Second },
+    )
+    .unwrap();
+    assert_eq!(d.to_string(), "2022-01-01");
+}
+
+#[test]
+fn test_date_parse_timestamp_unit_millisecond() {
+    use speedate::{Date, DateConfig, TimestampUnit};
+    let d = Date::parse_str_with_config(
+        "1640995200000",
+        &DateConfig { timestamp_unit: TimestampUnit::Millisecond },
+    )
+    .unwrap();
+    assert_eq!(d.to_string(), "2022-01-01");
+}
+
+#[test]
+fn test_datetime_parse_timestamp_units() {
+    use speedate::{DateTime, DateTimeConfig, TimeConfigBuilder, TimestampUnit};
+    let dt_sec = DateTime::parse_str_with_config(
+        "1641039194",
+        &DateTimeConfig {
+            timestamp_unit: TimestampUnit::Second,
+            time_config: TimeConfigBuilder::new().build(),
+        },
+    )
+    .unwrap();
+    assert_eq!(dt_sec.to_string(), "2022-01-01T12:13:14");
+
+    let dt_ms = DateTime::parse_str_with_config(
+        "1641039194000",
+        &DateTimeConfig {
+            timestamp_unit: TimestampUnit::Millisecond,
+            time_config: TimeConfigBuilder::new().build(),
+        },
+    )
+    .unwrap();
+    assert_eq!(dt_ms.to_string(), "2022-01-01T12:13:14");
 }


### PR DESCRIPTION
This is a continuation of https://github.com/pydantic/speedate/pull/54.

I took inspiration from there and comments, and added some util functions to get the `ms` timestamp from a function.

I did most of this by hand but full disclosure used some AI to help assist.